### PR TITLE
[fix] WordPressファイルの管理のためvolumesを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mysql/
 phpmyadmin/
+www/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 mysql/
 phpmyadmin/
-www/
+html/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # WordPressWithDocker
 WordPressが立ち上がるDockerを作る
 
-clone後docker-compose up -dでlocalhostポート8080に接続する
+## Usage
+現状、clone後にdocker-compose up -dで起動し
+localhostのポート8080に接続するとWordPressサーバー、
+ポート3306に接続するとPHPMｙAdmin
+が使用できる。
+WordPressのファイルはコンテナ起動後に作成されるwww/html内に保存される

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         links:
             - db:mysql
         volumes:
-            - ./www/html:/var/www/html
+            - .html:/var/www/html
         environment:
             WORDPRESS_DB_PASSWORD: "password"
     db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
             - "8080:80"
         links:
             - db:mysql
+        volumes:
+            - ./www/html:/var/www/html
         environment:
             WORDPRESS_DB_PASSWORD: "password"
     db:
@@ -17,7 +19,7 @@ services:
             MYSQL_DATABASE: "wordpress"
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
-        links:
+        depends_on:
             - db
         ports:
             - 3306:80


### PR DESCRIPTION
WordPressのファイルの置き場所をdocker-compose.yml内でvolumes指定することでわかりやすくしました。